### PR TITLE
feature/#136-date-picker-disable-future

### DIFF
--- a/packages/dodam-design-system/package.json
+++ b/packages/dodam-design-system/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@b1nd/dodam-design-system",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "private": false,
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/dodam-design-system/src/components/pickers/ui/DatePicker/index.tsx
+++ b/packages/dodam-design-system/src/components/pickers/ui/DatePicker/index.tsx
@@ -7,7 +7,7 @@ import * as S from "./style";
 import { colors } from "@/colors";
 import { DAYS } from "../../constants";
 import { getIsPast } from "../../utils/get-is-past";
-import { getIsFuture } from '../../utils/get-is-future';
+import { getIsFuture } from "../../utils/get-is-future";
 import { useDatePickerContent } from "../../hooks/useDatePickerContent";
 import { FilledButton } from "../../../buttons";
 
@@ -32,17 +32,17 @@ interface CalendarGridProps {
   calendar: ReturnType<typeof useDatePickerContent>["calendar"];
   selected: Date;
   disablePast: boolean;
-  disableFuture?: number;
+  maxSelectableDays?: number;
   onDayClick: (date: Date) => void;
 }
 
 const CalendarGrid = memo(
-  ({ calendar, selected, disablePast, disableFuture, onDayClick }: CalendarGridProps) => (
+  ({ calendar, selected, disablePast, maxSelectableDays, onDayClick }: CalendarGridProps) => (
     <S.Grid>
       {calendar.map((cell, i) => {
         if (!cell.day) return <div key={i} />;
         const isPast = disablePast && getIsPast(cell.date);
-        const isFuture = disableFuture !== undefined && getIsFuture(cell.date, disableFuture);
+        const isFuture = maxSelectableDays !== undefined && getIsFuture(cell.date, maxSelectableDays);
         const isDisabled = isPast || isFuture;
         return (
           <S.Day
@@ -102,7 +102,7 @@ export interface DatePickerContentProps {
   date?: Date;
   onChangeDate?: (date: Date) => void;
   disablePast?: boolean;
-  disableFuture?: number;
+  maxSelectableDays?: number;
   title?: string;
   onClose?: () => void;
 }
@@ -112,7 +112,7 @@ const DatePickerContent = memo(
     date = new Date(),
     onChangeDate,
     disablePast = false,
-    disableFuture,
+    maxSelectableDays,
     title = "날짜 선택",
     onClose,
   }: DatePickerContentProps) => {
@@ -138,7 +138,7 @@ const DatePickerContent = memo(
             calendar={calendar}
             selected={selected}
             disablePast={disablePast}
-            disableFuture={disableFuture}
+            maxSelectableDays={maxSelectableDays}
             onDayClick={handleDayClick}
           />
         </div>
@@ -157,7 +157,7 @@ export interface DatePickerProps {
   date?: Date;
   onChangeDate?: (date: Date) => void;
   disablePast?: boolean;
-  disableFuture?: number;
+  maxSelectableDays?: number;
   title?: string;
   onClose?: () => void;
   onExited?: () => void;
@@ -170,7 +170,7 @@ const DatePickerBase = memo(
     date = new Date(),
     onChangeDate,
     disablePast = false,
-    disableFuture,
+    maxSelectableDays,
     title = "날짜 선택",
     onClose,
     onExited,
@@ -206,7 +206,7 @@ const DatePickerBase = memo(
                 calendar={calendar}
                 selected={selected}
                 disablePast={disablePast}
-                disableFuture={disableFuture}
+                maxSelectableDays={maxSelectableDays}
                 onDayClick={handleDayClick}
               />
             </div>

--- a/packages/dodam-design-system/src/components/pickers/ui/DatePicker/index.tsx
+++ b/packages/dodam-design-system/src/components/pickers/ui/DatePicker/index.tsx
@@ -7,6 +7,7 @@ import * as S from "./style";
 import { colors } from "@/colors";
 import { DAYS } from "../../constants";
 import { getIsPast } from "../../utils/get-is-past";
+import { getIsFuture } from '../../utils/get-is-future';
 import { useDatePickerContent } from "../../hooks/useDatePickerContent";
 import { FilledButton } from "../../../buttons";
 
@@ -31,22 +32,25 @@ interface CalendarGridProps {
   calendar: ReturnType<typeof useDatePickerContent>["calendar"];
   selected: Date;
   disablePast: boolean;
+  disableFuture?: number;
   onDayClick: (date: Date) => void;
 }
 
 const CalendarGrid = memo(
-  ({ calendar, selected, disablePast, onDayClick }: CalendarGridProps) => (
+  ({ calendar, selected, disablePast, disableFuture, onDayClick }: CalendarGridProps) => (
     <S.Grid>
       {calendar.map((cell, i) => {
         if (!cell.day) return <div key={i} />;
         const isPast = disablePast && getIsPast(cell.date);
+        const isFuture = disableFuture !== undefined && getIsFuture(cell.date, disableFuture);
+        const isDisabled = isPast || isFuture;
         return (
           <S.Day
             key={i}
             $selected={selected?.toDateString() === cell.date?.toDateString()}
-            $isPast={isPast}
-            disabled={isPast}
-            onClick={isPast ? undefined : () => onDayClick(cell.date!)}
+            $disabled={isDisabled}
+            disabled={isDisabled}
+            onClick={isDisabled ? undefined : () => onDayClick(cell.date!)}
           >
             {cell.day}
           </S.Day>
@@ -98,6 +102,7 @@ export interface DatePickerContentProps {
   date?: Date;
   onChangeDate?: (date: Date) => void;
   disablePast?: boolean;
+  disableFuture?: number;
   title?: string;
   onClose?: () => void;
 }
@@ -107,6 +112,7 @@ const DatePickerContent = memo(
     date = new Date(),
     onChangeDate,
     disablePast = false,
+    disableFuture,
     title = "날짜 선택",
     onClose,
   }: DatePickerContentProps) => {
@@ -132,6 +138,7 @@ const DatePickerContent = memo(
             calendar={calendar}
             selected={selected}
             disablePast={disablePast}
+            disableFuture={disableFuture}
             onDayClick={handleDayClick}
           />
         </div>
@@ -150,6 +157,7 @@ export interface DatePickerProps {
   date?: Date;
   onChangeDate?: (date: Date) => void;
   disablePast?: boolean;
+  disableFuture?: number;
   title?: string;
   onClose?: () => void;
   onExited?: () => void;
@@ -162,6 +170,7 @@ const DatePickerBase = memo(
     date = new Date(),
     onChangeDate,
     disablePast = false,
+    disableFuture,
     title = "날짜 선택",
     onClose,
     onExited,
@@ -197,6 +206,7 @@ const DatePickerBase = memo(
                 calendar={calendar}
                 selected={selected}
                 disablePast={disablePast}
+                disableFuture={disableFuture}
                 onDayClick={handleDayClick}
               />
             </div>

--- a/packages/dodam-design-system/src/components/pickers/ui/DatePicker/style.ts
+++ b/packages/dodam-design-system/src/components/pickers/ui/DatePicker/style.ts
@@ -71,17 +71,17 @@ export const Grid = styled.div`
   grid-template-columns: repeat(7, 1fr);
 `;
 
-export const Day = styled.button<{ $selected?: boolean; $isPast?: boolean }>`
+export const Day = styled.button<{ $selected?: boolean; $disabled?: boolean }>`
   ${typoCss("Headline", "Medium")}
   height: 38px;
   border-radius: ${shapes.small};
   border: none;
-  cursor: ${({ $isPast }) => ($isPast ? "default" : "pointer")};
+  cursor: ${({ $disabled }) => ($disabled ? "default" : "pointer")};
   background: ${({ $selected }) =>
     $selected ? colors.brand.primary : "transparent"};
   color: ${({ $selected }) =>
     $selected ? colors.static.white : colors.text.tertiary};
-  opacity: ${({ $isPast }) => ($isPast ? 0.3 : 1)};
+  opacity: ${({ $disabled }) => ($disabled ? 0.3 : 1)};
 
   &:hover:not(:disabled) {
     background: ${({ $selected }) =>

--- a/packages/dodam-design-system/src/components/pickers/utils/get-is-future.ts
+++ b/packages/dodam-design-system/src/components/pickers/utils/get-is-future.ts
@@ -1,0 +1,12 @@
+export const getIsFuture = (date: Date | null, days = 0) => {
+  if (!date) return false;
+
+  const targetDate = new Date(date);
+  targetDate.setHours(0, 0, 0, 0);
+
+  const maxDate = new Date();
+  maxDate.setHours(0, 0, 0, 0);
+  maxDate.setDate(maxDate.getDate() + days);
+
+  return targetDate > maxDate;
+};


### PR DESCRIPTION
## 변경 내용

DatePicker에서 선택 가능한 미래 날짜 범위를 제한할 수 있도록 maxSelectableDays prop을 추가했습니다.


## 관련 이슈

<!-- 관련된 이슈를 연결해주세요 -->
- Resolves #136


## 테스트 방법

<!-- 어떻게 테스트했는지 설명해주세요 -->
- [ ] 단위 테스트 추가/수정
- [ ] 통합 테스트 완료
- [x] 수동 테스트 완료


## 스크린샷 (UI 변경 시)

<!-- UI 변경이 있다면 Before/After 스크린샷을 첨부해주세요 -->

### Before
<!-- 변경 전 스크린샷 -->
<img width="219" height="287" alt="스크린샷 2026-06-17 오후 6 07 34" src="https://github.com/user-attachments/assets/40cc6bf9-2d0b-454d-8cda-efe2c8d8d344" />

### After
<!-- 변경 후 스크린샷 -->
<img width="299" height="396" alt="스크린샷 2026-06-17 오후 6 07 48" src="https://github.com/user-attachments/assets/6c558454-0433-41ff-9440-c31706c77af4" />


## 체크리스트

- [x] 코드가 프로젝트의 코딩 스타일을 따릅니다
- [x] 자체 코드 리뷰를 완료했습니다
- [ ] 변경 사항에 대한 테스트를 추가했습니다
- [ ] 문서를 업데이트했습니다 (필요한 경우)
- [x] Breaking Changes가 없습니다


## 기타 사항

<!-- 리뷰어가 특별히 주의해서 봐야 할 부분이나 추가 설명 -->